### PR TITLE
Fix two issues and open a pull request

### DIFF
--- a/goodpapers/convex/arxiv/api.ts
+++ b/goodpapers/convex/arxiv/api.ts
@@ -107,7 +107,7 @@ export async function fetchArxivMetadata(
   }
 
   // Extract title (trim whitespace and newlines)
-  const title = entry.title?.replace(/\s+/g, " ").trim();
+  const title = entry.title.replace(/\s+/g, " ").trim();
 
   // Extract abstract (trim whitespace)
   const abstract = entry.summary?.replace(/\s+/g, " ").trim() || "";
@@ -146,11 +146,11 @@ async function fetchWithRetry(
   timeoutMs = 15000
 ): Promise<Response> {
   for (let i = 0; i < maxRetries; i++) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      timer = setTimeout(() => controller.abort(), timeoutMs);
       const response = await fetch(url, { ...init, signal: controller.signal });
-      clearTimeout(timer);
 
       if (response.ok) {
         return response;
@@ -194,6 +194,8 @@ async function fetchWithRetry(
       }
       if (i === maxRetries - 1) throw error;
       await new Promise((resolve) => setTimeout(resolve, baseDelayMs * Math.pow(2, i)));
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 


### PR DESCRIPTION
Fixes ArXiv API issues by removing unnecessary optional chaining from title extraction and preventing a timeout leak in `fetchWithRetry`.

The optional chaining on `entry.title` was causing type conflicts as `entry.title` is guaranteed to be a string. The `fetchWithRetry` function had a timer leak where `clearTimeout` was not called in all execution paths (e.g., on error or retry), leading to unmanaged timers; this is now resolved by using a `finally` block.

---
<a href="https://cursor.com/background-agent?bcId=bc-210fda5a-9099-4a1b-9b76-aa00d00d3af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-210fda5a-9099-4a1b-9b76-aa00d00d3af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of arXiv fetching by enforcing valid titles and providing clearer errors when titles are missing.
  * Ensured retry timeouts are always cleaned up, preventing potential hangs and improving overall stability during network retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->